### PR TITLE
Add 'aws' badge to ShieldsBadge component and Sniff & Step project

### DIFF
--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -1,6 +1,6 @@
 import { getLocales } from '@/utils/getLocales'
-import { LocaleHome, Locales } from '@/types'
 import { Career, Portfolio } from '@/components'
+import { LocaleHome, Locales } from '@/types'
 
 interface Props {
   params: { lang: Locales }

--- a/components/ShieldsBadge.tsx
+++ b/components/ShieldsBadge.tsx
@@ -1,4 +1,4 @@
-export type Badge = 'react' | 'nextjs' | 'nestjs' | 'docker' | 'jest' | 'typescript' | 'shell' | 'tailwind' | 'chromeExtension'
+export type Badge = 'react' | 'nextjs' | 'nestjs' | 'docker' | 'jest' | 'typescript' | 'shell' | 'tailwind' | 'chromeExtension' | 'aws'
 
 const badgeConfig: Record<Badge, { name: string; logo: string; logoColor?: string }> = {
   react: { name: 'React.js', logo: 'react' },
@@ -9,7 +9,8 @@ const badgeConfig: Record<Badge, { name: string; logo: string; logoColor?: strin
   typescript: { name: 'TypeScript', logo: 'typescript', logoColor: '3178C6' },
   shell: { name: 'Shell', logo: 'gnu-bash', logoColor: '4EAA25' },
   tailwind: { name: 'TailwindCSS', logo: 'tailwindcss', logoColor: '38B2AC' },
-  chromeExtension: { name: 'Chrome_Extension', logo: 'google-chrome', logoColor: 'white' }
+  chromeExtension: { name: 'Chrome_Extension', logo: 'google-chrome', logoColor: 'white' },
+  aws: { name: 'Amazon Web Service', logo: 'amazonwebservices', logoColor: 'ff9900' }
 }
 
 interface Props {
@@ -17,9 +18,14 @@ interface Props {
 }
 
 export function ShieldsBadge({ badges }: Props) {
+  const set: Set<Badge> = new Set()
+  for (const badge of badges) {
+    set.add(badge)
+  }
+
   return (
     <div className="flex flex-wrap gap-2 mb-8">
-      {badges.map((badgeKey) => {
+      {Array.from(set).map((badgeKey) => {
         const badge = badgeConfig[badgeKey] || {
           name: badgeKey,
           logo: 'javascript',

--- a/locales/home/en.json
+++ b/locales/home/en.json
@@ -110,7 +110,7 @@
       {
         "title": "Sniff & Step",
         "source": "https://github.com/Minthug/Sniff-Step",
-        "badges": ["nextjs", "tailwind", "typescript", "docker", "shell"],
+        "badges": ["nextjs", "tailwind", "typescript", "docker", "shell", "aws"],
         "description": "Neighborhood-based dog walking platform",
         "motivate": "Let's create a platform for busy people who can't find time to walk their dogs",
         "images": {

--- a/locales/home/ko.json
+++ b/locales/home/ko.json
@@ -110,7 +110,7 @@
       {
         "title": "Sniff & Step",
         "source": "https://github.com/Minthug/Sniff-Step",
-        "badges": ["nextjs", "tailwind", "typescript", "docker", "shell"],
+        "badges": ["nextjs", "tailwind", "typescript", "docker", "shell", "aws"],
         "description": "동네 기반 반려견 산책 대행 플랫폼",
         "motivate": "반려견 산책 시간을 만들 수 없는 바쁜 현대인을 위한 플랫폼을 만들어보자",
         "images": {


### PR DESCRIPTION
This pull request introduces updates to improve badge functionality and localization data. The most significant changes include adding support for an AWS badge, ensuring unique badge rendering, and updating localization files to reflect the new badge.

### Badge Functionality Enhancements:

* Added a new badge type, `'aws'`, to the `Badge` type and its corresponding configuration in `badgeConfig`. The AWS badge includes a name, logo, and logo color. (`components/ShieldsBadge.tsx`, [[1]](diffhunk://#diff-bdb2fe08dad91c99fb91dd105f785905c7905d26e1ab504b314fe48a12dcdad6L1-R1) [[2]](diffhunk://#diff-bdb2fe08dad91c99fb91dd105f785905c7905d26e1ab504b314fe48a12dcdad6L12-R28)
* Ensured unique badge rendering by converting the `badges` array into a `Set` before mapping over it in the `ShieldsBadge` component. This prevents duplicate badges from being displayed. (`components/ShieldsBadge.tsx`, [components/ShieldsBadge.tsxL12-R28](diffhunk://#diff-bdb2fe08dad91c99fb91dd105f785905c7905d26e1ab504b314fe48a12dcdad6L12-R28))

### Localization Updates:

* Updated the `en.json` and `ko.json` localization files to include the new `'aws'` badge for the "Sniff & Step" project. (`locales/home/en.json`, [[1]](diffhunk://#diff-123f549daef3e77f4abbe3775ed21763898eea03a3fb48a66b7d17d364063edaL113-R113); `locales/home/ko.json`, [[2]](diffhunk://#diff-70ae956d6fe19629dfd9c4edf58202d3b899d2651940f6835e5014ad6f440bdfL113-R113)

### Code Cleanup:

* Reordered imports in `app/[lang]/page.tsx` to align with best practices, moving type imports after component imports. (`app/[lang]/page.tsx`, [app/[lang]/page.tsxL2-R3](diffhunk://#diff-91366a657d078a49de370692ab5f1ab96c89a128a2c1fc8ed51df2f610fa260aL2-R3))